### PR TITLE
Fix default API base URL resolution

### DIFF
--- a/apps/src/main.ts
+++ b/apps/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3001);
 }
 bootstrap();

--- a/apps/web/config.js
+++ b/apps/web/config.js
@@ -1,6 +1,8 @@
 // apps/web/config.js
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
-  "https://super-duper-tribble-7vj9q9gwpv4jhxxjp-3000.app.github.dev";
+  (process.env.CODESPACE_NAME && process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+    ? `https://${process.env.CODESPACE_NAME}-3001.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+    : 'http://localhost:3001');
 
 export default API_BASE_URL;

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,6 +1,7 @@
 // apps/web/pages/index.tsx
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import API_BASE_URL from '../config';
 
 type Merchant = { id: number; name: string; url: string | null };
 type Offer = {
@@ -14,7 +15,7 @@ type Offer = {
 };
 type Product = { id: number; name: string; description: string | null; offers: Offer[] };
 
-const API = process.env.NEXT_PUBLIC_API_URL;
+const API = API_BASE_URL;
 
 export default function Home() {
   const [q, setQ] = useState('');


### PR DESCRIPTION
## Summary
- change the Nest API default port to 3001 to avoid clashing with the Next.js dev server
- compute a sensible default API base URL for the web app that supports Codespaces and local development
- use the shared API base configuration inside the homepage fetch logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a660d42483258e7f2693f4d041c8