### PR TITLE
Fix default API base URL resolution and enable CORS

### DIFF
--- a/apps/src/main.ts
+++ b/apps/src/main.ts
@@ -2,7 +2,12 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+  const app = await NestFactory.create(AppModule, {
+    cors: {
+      origin: true,
+      credentials: true,
+    },
+  });
+  await app.listen(process.env.PORT ?? 3001, '0.0.0.0');
 }
 bootstrap();

--- a/apps/web/config.js
+++ b/apps/web/config.js
@@ -1,6 +1,8 @@
 // apps/web/config.js
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
-  "https://super-duper-tribble-7vj9q9gwpv4jhxxjp-3000.app.github.dev";
+  (process.env.CODESPACE_NAME && process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+    ? `https://${process.env.CODESPACE_NAME}-3001.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
+    : 'http://localhost:3001');
 
 export default API_BASE_URL;

--- a/apps/web/config.js
+++ b/apps/web/config.js
@@ -1,8 +1,40 @@
 // apps/web/config.js
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.CODESPACE_NAME && process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
-    ? `https://${process.env.CODESPACE_NAME}-3001.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`
-    : 'http://localhost:3001');
+const DEFAULT_PORT = process.env.API_PORT ?? '3001';
 
-export default API_BASE_URL;
+const fromEnv = () => {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
+
+  if (process.env.CODESPACE_NAME && process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN) {
+    return `https://${process.env.CODESPACE_NAME}-${DEFAULT_PORT}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return null;
+};
+
+const fromWindowLocation = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const { protocol, hostname } = window.location;
+
+  if (!hostname) {
+    return null;
+  }
+
+  if (hostname.endsWith('.app.github.dev')) {
+    return `https://${hostname.replace(/-\d+(?=\.app\.github\.dev$)/, `-${DEFAULT_PORT}`)}`;
+  }
+
+  return `${protocol}//${hostname}:${DEFAULT_PORT}`;
+};
+
+const getApiBaseUrl = () => fromEnv() ?? fromWindowLocation() ?? `http://localhost:${DEFAULT_PORT}`;
+
+export default getApiBaseUrl;

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,7 +1,7 @@
 // apps/web/pages/index.tsx
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import API_BASE_URL from '../config';
+import getApiBaseUrl from '../config';
 
 type Merchant = { id: number; name: string; url: string | null };
 type Offer = {
@@ -15,7 +15,7 @@ type Offer = {
 };
 type Product = { id: number; name: string; description: string | null; offers: Offer[] };
 
-const API = API_BASE_URL;
+const API = getApiBaseUrl();
 
 export default function Home() {
   const [q, setQ] = useState('');

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,6 +1,7 @@
 // apps/web/pages/index.tsx
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import API_BASE_URL from '../config';
 
 type Merchant = { id: number; name: string; url: string | null };
 type Offer = {
@@ -14,7 +15,7 @@ type Offer = {
 };
 type Product = { id: number; name: string; description: string | null; offers: Offer[] };
 
-const API = process.env.NEXT_PUBLIC_API_URL;
+const API = API_BASE_URL;
 
 export default function Home() {
   const [q, setQ] = useState('');


### PR DESCRIPTION
## Summary
- change the Nest API default port to 3001 to avoid clashing with the Next.js dev server
- compute a sensible default API base URL for the web app that supports Codespaces and local development
- use the shared API base configuration inside the homepage fetch logic
- enable CORS and bind the Nest API to all interfaces so the frontend can reach it in Codespaces

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a660d42483258e7f2693f4d041c8