### PR TITLE
Fix Nest API TypeScript configuration for dev server

### DIFF
--- a/apps/src/products/products.service.ts
+++ b/apps/src/products/products.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import type { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -9,7 +8,7 @@ export class ProductsService {
   findAll(query?: string) {
     const trimmed = query?.trim();
 
-    const where: Prisma.ProductWhereInput | undefined = trimmed
+    const where = trimmed
       ? {
           OR: [
             { name: { contains: trimmed, mode: 'insensitive' } },

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -21,5 +21,13 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "./web",
+    "../workers",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- scope the Nest workspace tsconfig to the API sources so the dev server no longer tries to compile the Next.js app or workers
- drop the Prisma namespace type dependency in the products service to avoid build-time coupling on generated Prisma types

## Testing
- pnpm --filter api start -- --help *(fails: @prisma/client runtime not generated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c95cbd708325a1ca387dd2273008