### PR TITLE
Improve API error handling on home page

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -36,7 +36,11 @@ export default function Home() {
       const json = await res.json();
       setData(json);
     } catch (e: any) {
-      setError(e?.message ?? 'Erreur inconnue');
+      if (e instanceof TypeError || e?.name === 'TypeError') {
+        setError('API indisponible : vérifiez que `pnpm dev:api` tourne sur http://localhost:3001');
+      } else {
+        setError(e?.message ?? 'Erreur inconnue');
+      }
       setData([]);
     } finally {
       setLoading(false);
@@ -69,7 +73,7 @@ export default function Home() {
         </form>
 
         {loading && <p>Chargement...</p>}
-        {error && <p style={{ color: 'crimson' }}>Erreur: {error}</p>}
+        {error && <p style={{ color: 'crimson' }}>{error}</p>}
 
         {!loading && !error && data.length === 0 && <p>Aucun produit.</p>}
 


### PR DESCRIPTION
## Summary
- add a dedicated message when fetch encounters a network error on the home page
- keep HTTP error messaging intact to differentiate backend issues
- show the friendly error text directly in the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d35d57d08325bd6de8e91db9e36f