### PR TITLE
feat: add product detail endpoint and page

### DIFF
--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -13,7 +13,10 @@ try {
 } catch (error) {
   if (process.env.NODE_ENV === 'test') {
     PrismaClient = class {
-      product = { findMany: async () => [] };
+      product = {
+        findMany: async () => [],
+        findUnique: async () => null,
+      };
       async $connect() {}
       async $disconnect() {}
     } as unknown as PrismaClientCtor;

--- a/apps/api/src/products/products.controller.ts
+++ b/apps/api/src/products/products.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ProductsService } from './products.service';
 
 @Controller('products')
@@ -8,5 +8,14 @@ export class ProductsController {
   @Get()
   list(@Query('q') q?: string) {
     return this.productsService.findAll(q);
+  }
+
+  @Get(':id')
+  async detail(@Param('id', ParseIntPipe) id: number) {
+    const product = await this.productsService.findOne(id);
+    if (!product) {
+      throw new NotFoundException('Produit introuvable');
+    }
+    return product;
   }
 }

--- a/apps/api/src/products/products.service.spec.ts
+++ b/apps/api/src/products/products.service.spec.ts
@@ -8,6 +8,7 @@ describe('ProductsService', () => {
   let prisma: PrismaService;
 
   const findMany = jest.fn();
+  const findUnique = jest.fn();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,7 +16,7 @@ describe('ProductsService', () => {
         ProductsService,
         {
           provide: PrismaService,
-          useValue: { product: { findMany } },
+          useValue: { product: { findMany, findUnique } },
         },
       ],
     }).compile();
@@ -26,6 +27,7 @@ describe('ProductsService', () => {
 
   afterEach(() => {
     findMany.mockReset();
+    findUnique.mockReset();
   });
 
   it('returns all products when no query is provided', () => {
@@ -65,5 +67,23 @@ describe('ProductsService', () => {
       },
       orderBy: { name: 'asc' },
     });
+  });
+
+  it('finds a product by id', async () => {
+    const product = { id: 1, name: 'iPhone 15' };
+    findUnique.mockResolvedValue(product);
+
+    const result = await service.findOne(1);
+
+    expect(prisma.product.findUnique).toHaveBeenCalledWith({
+      where: { id: 1 },
+      include: {
+        offers: {
+          include: { merchant: true },
+          orderBy: { price: 'asc' },
+        },
+      },
+    });
+    expect(result).toBe(product);
   });
 });

--- a/apps/api/src/products/products.service.ts
+++ b/apps/api/src/products/products.service.ts
@@ -28,4 +28,16 @@ export class ProductsService {
       orderBy: { name: 'asc' },
     });
   }
+
+  findOne(id: number) {
+    return this.prisma.product.findUnique({
+      where: { id },
+      include: {
+        offers: {
+          include: { merchant: true },
+          orderBy: { price: 'asc' },
+        },
+      },
+    });
+  }
 }

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,27 +1,17 @@
 // apps/web/pages/index.tsx
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 
 import getApiBaseUrl from '../config';
-
-type Merchant = { id: number; name: string; url: string | null };
-type Offer = {
-  id: number;
-  price: number;
-  deliveryFee: number | null;
-  paymentMethods: string[];
-  productId: number;
-  merchantId: number;
-  merchant: Merchant;
-};
-type Product = { id: number; name: string; description: string | null; offers: Offer[] };
+import type { ProductWithOffers } from '../types/product';
 
 const API = getApiBaseUrl();
 
 export default function Home() {
   const [q, setQ] = useState('');
   const [loading, setLoading] = useState(false);
-  const [data, setData] = useState<Product[]>([]);
+  const [data, setData] = useState<ProductWithOffers[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   const fetchProducts = async (query?: string) => {
@@ -80,7 +70,11 @@ export default function Home() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(260px,1fr))', gap: 16 }}>
           {data.map((p) => (
             <article key={p.id} style={{ border: '1px solid #eee', borderRadius: 12, padding: 12 }}>
-              <h3 style={{ margin: '0 0 8px' }}>{p.name}</h3>
+              <h3 style={{ margin: '0 0 8px' }}>
+                <Link href={`/products/${p.id}`} style={{ color: '#1d4ed8', textDecoration: 'none' }}>
+                  {p.name}
+                </Link>
+              </h3>
               {p.description && <p style={{ margin: '0 0 12px', color: '#666' }}>{p.description}</p>}
               <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                 {p.offers.map((o) => (

--- a/apps/web/pages/products/[id].tsx
+++ b/apps/web/pages/products/[id].tsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import getApiBaseUrl from '../../config';
+import type { ProductWithOffers } from '../../types/product';
+
+const API = getApiBaseUrl();
+
+export default function ProductDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [product, setProduct] = useState<ProductWithOffers | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const productId = useMemo(() => {
+    if (!id) return null;
+    if (Array.isArray(id)) return id[0] ?? null;
+    return id;
+  }, [id]);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!productId) {
+      setError('Identifiant de produit invalide.');
+      setProduct(null);
+      return;
+    }
+
+    const numericId = Number(productId);
+    if (!Number.isInteger(numericId) || numericId <= 0) {
+      setError('Identifiant de produit invalide.');
+      setProduct(null);
+      return;
+    }
+
+    let aborted = false;
+
+    const fetchProduct = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await fetch(`${API}/products/${numericId}`, {
+          headers: { Accept: 'application/json' },
+        });
+
+        if (res.status === 404) {
+          if (!aborted) {
+            setError('Produit introuvable.');
+            setProduct(null);
+          }
+          return;
+        }
+
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const json = (await res.json()) as ProductWithOffers;
+        if (!aborted) {
+          setProduct(json);
+        }
+      } catch (e: unknown) {
+        if (aborted) return;
+        if (e instanceof TypeError || (e as { name?: string })?.name === 'TypeError') {
+          setError('API indisponible : vérifiez que `pnpm --filter api dev` tourne sur http://localhost:3001');
+        } else {
+          setError((e as Error)?.message ?? 'Erreur inconnue');
+        }
+        setProduct(null);
+      } finally {
+        if (!aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchProduct();
+
+    return () => {
+      aborted = true;
+    };
+  }, [productId, router.isReady]);
+
+  const title = product ? `${product.name} - Atlas Taman` : 'Produit - Atlas Taman';
+
+  const formatMad = (value: number) => value.toLocaleString('fr-MA');
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <main style={{ maxWidth: 980, margin: '24px auto', padding: '0 16px' }}>
+        <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+          <span aria-hidden>←</span>
+          Retour aux produits
+        </Link>
+
+        {loading && <p>Chargement du produit...</p>}
+        {error && (
+          <p style={{ color: 'crimson', marginTop: 16 }} role="alert">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && !product && <p>Aucun produit à afficher.</p>}
+
+        {product && (
+          <article style={{ border: '1px solid #eee', borderRadius: 12, padding: 24 }}>
+            <header style={{ marginBottom: 24 }}>
+              <h1 style={{ margin: '0 0 12px' }}>{product.name}</h1>
+              {product.description && (
+                <p style={{ margin: 0, color: '#555', lineHeight: 1.5 }}>{product.description}</p>
+              )}
+            </header>
+
+            <section>
+              <h2 style={{ margin: '0 0 12px', fontSize: '1.25rem' }}>
+                Offres disponibles ({product.offers.length})
+              </h2>
+
+              {product.offers.length === 0 && <p>Aucune offre pour le moment.</p>}
+
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 16 }}>
+                {product.offers.map((offer) => {
+                  const total = offer.price + (offer.deliveryFee ?? 0);
+                  return (
+                    <li
+                      key={offer.id}
+                      style={{
+                        border: '1px solid #f1f1f1',
+                        borderRadius: 12,
+                        padding: 16,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <div>
+                          <strong style={{ fontSize: '1.1rem' }}>{formatMad(offer.price)} MAD</strong>
+                          {typeof offer.deliveryFee === 'number' && (
+                            <span style={{ marginLeft: 8, color: '#666' }}>
+                              Livraison {formatMad(offer.deliveryFee)} MAD
+                            </span>
+                          )}
+                        </div>
+                        <a
+                          href={offer.merchant?.url ?? '#'}
+                          target="_blank"
+                          rel="noreferrer"
+                          style={{ color: '#1d4ed8', textDecoration: 'none' }}
+                          title={offer.merchant?.name ?? 'Marchand'}
+                        >
+                          {offer.merchant?.name ?? 'Marchand'}
+                        </a>
+                      </div>
+                      <div style={{ fontSize: 13, color: '#666' }}>
+                        Moyens de paiement : {offer.paymentMethods.join(' · ')}
+                      </div>
+                      <div style={{ fontSize: 13, color: '#444' }}>
+                        Total estimé : <strong>{formatMad(total)} MAD</strong>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          </article>
+        )}
+      </main>
+    </>
+  );
+}

--- a/apps/web/pages/products/index.tsx
+++ b/apps/web/pages/products/index.tsx
@@ -1,4 +1,4 @@
-// apps/web/pages/products.tsx
+// apps/web/pages/products/index.tsx
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 export default function Products() {

--- a/apps/web/types/product.ts
+++ b/apps/web/types/product.ts
@@ -1,0 +1,23 @@
+export type Merchant = {
+  id: number;
+  name: string;
+  url: string | null;
+};
+
+export type Offer = {
+  id: number;
+  price: number;
+  deliveryFee: number | null;
+  paymentMethods: string[];
+  productId: number;
+  merchantId: number;
+  merchant: Merchant;
+};
+
+export type Product = {
+  id: number;
+  name: string;
+  description: string | null;
+};
+
+export type ProductWithOffers = Product & { offers: Offer[] };


### PR DESCRIPTION
## Summary
- expose a GET `/products/:id` endpoint that returns a product with its offers and ensures 404 handling
- cover the new service method with unit tests and extend the Prisma test stub for findUnique
- add a typed Next.js product detail page linked from the home grid and share product types in the web app

## Testing
- pnpm --filter api test -- --runTestsByPath src/products/products.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7dbdbda04832585d75b06f0d9b19f