### PR TITLE
Improve Codespaces API URL detection and SSR error status

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -46,6 +46,10 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> = async (cont
     const isNetworkError =
       error instanceof TypeError || (error as { name?: string })?.name === 'TypeError';
 
+    if (context.res) {
+      context.res.statusCode = isNetworkError ? 502 : 500;
+    }
+
     return {
       props: {
         products: [],


### PR DESCRIPTION
## Summary
- prioritize Codespaces host detection when building the API base URL so the frontend uses the forwarded domain instead of localhost
- expose helper utilities for Codespaces-aware resolution across server, browser, and environment contexts
- return a 502 status during SSR when the upstream API is unavailable and fall back to 500 for other errors

## Testing
- pnpm --filter web lint *(fails: next lint exits with "Invalid Options" due to legacy configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9421b17c0832584699972c360069e